### PR TITLE
[TOY-30] 깃헙 oauth 연동

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main", "develop"]
 
+permissions: write-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,3 +26,10 @@ jobs:
         env: # Or as an environment variable
           GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
         run: ./gradlew build --stacktrace
+
+      # 테스트 후 Result를 보기위해 Publish Unit Test Results step 추가
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: ${{ always() }}  # 테스트가 실패하여도 Report를 보기 위해 `always`로 설정
+        with:
+         files: build/test-results/**/*.xml

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Build with Gradle
         env: # Or as an environment variable
           GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
         run: ./gradlew build --stacktrace
 
       # 테스트 후 Result를 보기위해 Publish Unit Test Results step 추가

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Build with Gradle
         env: # Or as an environment variable
           GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
-        run: ./gradlew build --debug --stacktrace
+        run: ./gradlew build --stacktrace

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Build with Gradle
         env: # Or as an environment variable
           GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
-        run: ./gradlew build
+        run: ./gradlew build --debug --stackTrace

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Build with Gradle
         env: # Or as an environment variable
           GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
-        run: ./gradlew build --debug --stackTrace
+        run: ./gradlew build --debug --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${Versions.COROUTINE_VERSION}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.JACKSON_KOTLIN}")
 
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
@@ -22,7 +22,7 @@ class SecurityConfig(
             .addFilterBefore(GithubAuthFilter(githubService), UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests {
                 it
-                    .requestMatchers(HttpMethod.GET, "/login", "/github/login/callback")
+                    .requestMatchers(HttpMethod.GET, "/login", "/github/login/callback", "/error")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
                     .permitAll()

--- a/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
@@ -1,19 +1,25 @@
 package org.contribhub.api.config
 
+import org.contribhub.api.controller.filter.GithubAuthFilter
+import org.contribhub.api.service.GithubService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
-class SecurityConfig {
+class SecurityConfig(
+    private val githubService: GithubService,
+) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
         http
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .formLogin { it.disable() }
+            .addFilterBefore(GithubAuthFilter(githubService), UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests {
                 it
                     .requestMatchers(HttpMethod.GET, "/login", "/github/login/callback")

--- a/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/contribhub/api/config/SecurityConfig.kt
@@ -1,0 +1,26 @@
+package org.contribhub.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .formLogin { it.disable() }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers(HttpMethod.GET, "/login", "/github/login/callback")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }.build()
+}

--- a/src/main/kotlin/org/contribhub/api/controller/GithubController.kt
+++ b/src/main/kotlin/org/contribhub/api/controller/GithubController.kt
@@ -3,6 +3,8 @@ package org.contribhub.api.controller
 import org.contribhub.api.infra.http.dto.GithubCodeToAccessTokenResponse
 import org.contribhub.api.infra.http.dto.GithubRepositoryResponse
 import org.contribhub.api.service.GithubService
+import org.contribhub.api.service.dto.UserInfo
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -26,5 +28,11 @@ class GithubController(
     @GetMapping("/login/callback")
     suspend fun callback(
         @RequestParam code: String,
-    ): GithubCodeToAccessTokenResponse = githubService.accessToken(code)
+    ): GithubCodeToAccessTokenResponse = githubService.resolveCodeToAccessToken(code)
+
+    @Deprecated("For Test Purpose Only")
+    @GetMapping("/auth-test")
+    fun authenticationTest(
+        @AuthenticationPrincipal user: UserInfo,
+    ): UserInfo = user
 }

--- a/src/main/kotlin/org/contribhub/api/controller/GithubController.kt
+++ b/src/main/kotlin/org/contribhub/api/controller/GithubController.kt
@@ -1,5 +1,6 @@
 package org.contribhub.api.controller
 
+import org.contribhub.api.infra.http.dto.GithubCodeToAccessTokenResponse
 import org.contribhub.api.infra.http.dto.GithubRepositoryResponse
 import org.contribhub.api.service.GithubService
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,4 +22,9 @@ class GithubController(
         @RequestParam page: Int?,
     ): GithubRepositoryResponse =
         githubService.searchRepositories(query = query, sort = sort, order = order, perPage = perPage, page = page)
+
+    @GetMapping("/login/callback")
+    suspend fun callback(
+        @RequestParam code: String,
+    ): GithubCodeToAccessTokenResponse = githubService.accessToken(code)
 }

--- a/src/main/kotlin/org/contribhub/api/controller/ViewController.kt
+++ b/src/main/kotlin/org/contribhub/api/controller/ViewController.kt
@@ -3,13 +3,14 @@ package org.contribhub.api.controller
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.GetMapping
 
+@Deprecated("View Controller is will removed after front-end implementation")
 @Controller
 class ViewController(
     @Value("\${api.github.client-id}") private val clientId: String,
 ) {
-    @RequestMapping("/login")
+    @GetMapping("/login")
     fun loginPage(model: Model): String {
         model.addAttribute("clientId", clientId)
         return "loginView"

--- a/src/main/kotlin/org/contribhub/api/controller/ViewController.kt
+++ b/src/main/kotlin/org/contribhub/api/controller/ViewController.kt
@@ -1,0 +1,17 @@
+package org.contribhub.api.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+class ViewController(
+    @Value("\${api.github.client-id}") private val clientId: String,
+) {
+    @RequestMapping("/login")
+    fun loginPage(model: Model): String {
+        model.addAttribute("clientId", clientId)
+        return "loginView"
+    }
+}

--- a/src/main/kotlin/org/contribhub/api/controller/filter/GithubAuthFilter.kt
+++ b/src/main/kotlin/org/contribhub/api/controller/filter/GithubAuthFilter.kt
@@ -1,0 +1,37 @@
+package org.contribhub.api.controller.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import org.contribhub.api.service.GithubService
+import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+class GithubAuthFilter(
+    private val githubService: GithubService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val authHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
+        if (authHeader != null && authHeader.startsWith(ACCESS_TOKEN_PREFIX)) {
+            val accessToken = authHeader.substringAfter(ACCESS_TOKEN_PREFIX)
+
+            val user =
+                runBlocking {
+                    githubService.getAuthenticatedUser(accessToken).toUserInfo()
+                }
+            SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(user, null, emptyList())
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        private const val ACCESS_TOKEN_PREFIX = "Bearer "
+    }
+}

--- a/src/main/kotlin/org/contribhub/api/infra/http/GithubClient.kt
+++ b/src/main/kotlin/org/contribhub/api/infra/http/GithubClient.kt
@@ -1,9 +1,14 @@
 package org.contribhub.api.infra.http
 
+import org.contribhub.api.infra.http.dto.GithubCodeToAccessRequest
+import org.contribhub.api.infra.http.dto.GithubCodeToAccessTokenResponse
 import org.contribhub.api.infra.http.dto.GithubRepositoryResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
 
@@ -11,6 +16,8 @@ import org.springframework.web.reactive.function.client.awaitBody
 class GithubClient(
     private val webClient: WebClient,
     @Value("\${api.github.auth-token}") private val apiToken: String,
+    @Value("\${api.github.client-id}") private val clientId: String,
+    @Value("\${api.github.client-secret}") private val clientSecret: String,
 ) {
     private val host = "https://api.github.com"
 
@@ -38,8 +45,24 @@ class GithubClient(
                     .queryParam("per_page", perPage)
                     .queryParam("page", page)
                     .build()
-            }.headers {
-                it.add(HttpHeaders.AUTHORIZATION, "Bearer $apiToken")
-            }.retrieve()
+            }.header(HttpHeaders.AUTHORIZATION, "Bearer $apiToken")
+            .retrieve()
             .awaitBody()
+
+    /**
+     * @see<a href="https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps">Authorizing OAuth apps</a>
+     */
+    suspend fun codeToAccessToken(code: String): GithubCodeToAccessTokenResponse =
+        webClient
+            .post()
+            .uri("https://github.com/login/oauth/access_token")
+            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .body(
+                BodyInserters.fromValue(
+                    GithubCodeToAccessRequest(clientId = clientId, clientSecret = clientSecret, code = code),
+                ),
+            ).retrieve()
+            .onStatus(HttpStatusCode::is4xxClientError) {
+                throw IllegalArgumentException("Invalid Code ($code)")
+            }.awaitBody()
 }

--- a/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubCodeToAccessRequest.kt
+++ b/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubCodeToAccessRequest.kt
@@ -1,0 +1,11 @@
+package org.contribhub.api.infra.http.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class GithubCodeToAccessRequest(
+    val clientId: String,
+    val clientSecret: String,
+    val code: String,
+)

--- a/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubCodeToAccessTokenResponse.kt
+++ b/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubCodeToAccessTokenResponse.kt
@@ -1,0 +1,11 @@
+package org.contribhub.api.infra.http.dto
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class GithubCodeToAccessTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+    val tokenType: String,
+)

--- a/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubGetAuthenticatedUserResponse.kt
+++ b/src/main/kotlin/org/contribhub/api/infra/http/dto/GithubGetAuthenticatedUserResponse.kt
@@ -1,0 +1,14 @@
+package org.contribhub.api.infra.http.dto
+
+import org.contribhub.api.service.dto.UserInfo
+
+data class GithubGetAuthenticatedUserResponse(
+    val id: Long,
+    val login: String,
+) {
+    fun toUserInfo() =
+        UserInfo(
+            id = id,
+            nickname = login,
+        )
+}

--- a/src/main/kotlin/org/contribhub/api/service/GithubService.kt
+++ b/src/main/kotlin/org/contribhub/api/service/GithubService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.contribhub.api.infra.http.GithubClient
 import org.contribhub.api.infra.http.dto.GithubCodeToAccessTokenResponse
+import org.contribhub.api.infra.http.dto.GithubGetAuthenticatedUserResponse
 import org.contribhub.api.infra.http.dto.GithubRepositoryResponse
 import org.contribhub.api.infra.repository.RepositoryJpaRepository
 import org.contribhub.api.infra.repository.TopicJpaRepository
@@ -53,5 +54,8 @@ class GithubService(
         repositoryJpaRepository.upsertRepositories(repositories)
     }
 
-    suspend fun accessToken(code: String): GithubCodeToAccessTokenResponse = githubClient.codeToAccessToken(code)
+    suspend fun resolveCodeToAccessToken(code: String): GithubCodeToAccessTokenResponse = githubClient.resolveCodeToAccessToken(code)
+
+    suspend fun getAuthenticatedUser(accessToken: String): GithubGetAuthenticatedUserResponse =
+        githubClient.getAuthenticatedUser(accessToken)
 }

--- a/src/main/kotlin/org/contribhub/api/service/GithubService.kt
+++ b/src/main/kotlin/org/contribhub/api/service/GithubService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.contribhub.api.infra.http.GithubClient
+import org.contribhub.api.infra.http.dto.GithubCodeToAccessTokenResponse
 import org.contribhub.api.infra.http.dto.GithubRepositoryResponse
 import org.contribhub.api.infra.repository.RepositoryJpaRepository
 import org.contribhub.api.infra.repository.TopicJpaRepository
@@ -51,4 +52,6 @@ class GithubService(
     fun upsertRepositories(repositories: List<RepositoryEntity>) {
         repositoryJpaRepository.upsertRepositories(repositories)
     }
+
+    suspend fun accessToken(code: String): GithubCodeToAccessTokenResponse = githubClient.codeToAccessToken(code)
 }

--- a/src/main/kotlin/org/contribhub/api/service/dto/UserInfo.kt
+++ b/src/main/kotlin/org/contribhub/api/service/dto/UserInfo.kt
@@ -1,0 +1,6 @@
+package org.contribhub.api.service.dto
+
+data class UserInfo(
+    val id: Long,
+    val nickname: String,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,4 @@ api:
   github:
     auth-token: ${GIT_AUTH_TOKEN}
     client-id: ${CLIENT_ID}
+    client-secret: ${CLIENT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,4 @@ spring:
 api:
   github:
     auth-token: ${GIT_AUTH_TOKEN}
+    client-id: ${CLIENT_ID}

--- a/src/main/resources/templates/loginView.html
+++ b/src/main/resources/templates/loginView.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub SSO Login</title>
+    <style>
+        .github-login {
+            display: inline-block;
+            background-color: #333;
+            color: white;
+            padding: 10px 20px;
+            border-radius: 5px;
+            text-decoration: none;
+            font-size: 16px;
+            font-family: Arial, sans-serif;
+        }
+        .github-login:hover {
+            background-color: #444;
+        }
+    </style>
+</head>
+<body>
+<h2>Login with GitHub</h2>
+<a class="github-login" th:href="@{'https://github.com/login/oauth/authorize?client_id=' + ${clientId} + '&scope=user'}">
+    Sign in with GitHub
+</a>
+</body>
+</html>

--- a/src/test/kotlin/org/contribhub/api/controller/filter/GithubAuthFilterTest.kt
+++ b/src/test/kotlin/org/contribhub/api/controller/filter/GithubAuthFilterTest.kt
@@ -1,0 +1,30 @@
+package org.contribhub.api.controller.filter
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EmptySource
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@AutoConfigureWebTestClient
+class GithubAuthFilterTest(
+    private val webTestClient: WebTestClient,
+) {
+    @ParameterizedTest
+    @ValueSource(strings = ["Bearer InValidToken", "InValidToken"])
+    @EmptySource
+    fun `인증 실패 시 StatusCode 403 응답`(authorization: String) {
+        webTestClient
+            .get()
+            .uri("/github/auth-test")
+            .header(HttpHeaders.AUTHORIZATION, authorization)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+}


### PR DESCRIPTION
- [x] 테스트 실패 해소
- [x] 계정 정보 Resolving 실패시 401 응답

## 테스트 방법
### /login 접속
<img width="750" alt="스크린샷 2024-11-10 오후 12 36 38" src="https://github.com/user-attachments/assets/e62e9cda-da42-4869-bb97-7b579745b442">

### Sign In With Github 클릭 후 로그인

### Redirect 된 페이지에서 accessToken 복사
<img width="826" alt="image" src="https://github.com/user-attachments/assets/069b1d79-0bbb-4a38-96ca-556f6e186e74">

### 유저 정보 가져오기 테스트
```curl
curl --location 'http://localhost:8080/github/auth-test' \
--header 'Authorization: Bearer *****'
```
<img width="584" alt="스크린샷 2024-11-10 오후 12 39 56" src="https://github.com/user-attachments/assets/42d34fac-c4c1-40cc-9fc8-8c3b26959721">
